### PR TITLE
Out of bounds fix in dip.test

### DIFF
--- a/R/dipTest.R
+++ b/R/dipTest.R
@@ -27,8 +27,8 @@ dip.test <- function(x, simulate.p.value = FALSE, B = 2000)
 	max.n <- max(nn <- as.integer(dn[["n"]]))
 	P.s <- as.numeric(dn[["Pr"]])
 
-        if(n > max.n) { ## extrapolate, or rather just use the last n as == "asymptotic"
-            message("n = ",n," > max_n{n in table} = ",max.n,
+        if(n >= max.n) { ## extrapolate, or rather just use the last n as == "asymptotic"
+            message("n = ",n," >= max_n{n in table} = ",max.n,
                     " -- using that as asymptotic value.")
             n1 <- n0 <- max.n
             i2 <- i.n <- length(nn)


### PR DESCRIPTION
I found an out of bounds error in `dip.test` that occurs when the number of samples in the input data is exactly 72000.

If the number of samples is 71999 or less, `dip.test` gives correct behavior:
```{r}
dip.test(rnorm(71999,mean=0,sd=1))
```
... by returning the test results.

If the number of samples is 72001 or greater, `dip.test` gives correct behavior:
```{r}
dip.test(rnorm(72001,mean=0,sd=1))
```

... by returning the test results and also raising the warning:
```
n = 72001 > max_n{n in table} = 72000 -- using that as asymptotic value.
```

However, if the number of samples is exactly 72000, for example:

```{r}
dip.test(rnorm(72000,mean=0,sd=1))
```

... `dip.test` fails with the following error message:

```
Error in qDiptab[i2, ] : subscript out of bounds
```

To remedy this unexpected behavior, I changed the comparison between the number of samples and the maximum allowable number of samples in `dipTest.R` on line 30 from `>` to `>=`. Now the example


```{r}
dip.test(rnorm(72000,mean=0,sd=1))
```

... returns the test results and also raising the warning:

```
n = 72000 >= max_n{n in table} = 72000 -- using that as asymptotic value.
```



